### PR TITLE
feat: SQL as the default option for Code view

### DIFF
--- a/client/cypress/e2e/basic.cy.js
+++ b/client/cypress/e2e/basic.cy.js
@@ -36,14 +36,14 @@ describe("Substrait Fiddle Basic Test", () => {
       .click()
       .get("#editor")
       .type("{moveToEnd}")
+      .contains("#editor", "-- Enter SQL query to generate Substrait Plan");
+
+    cy.get("#language")
+      .select("json")
+      .get("#editor")
       .contains(
         "#editor",
         '{"_comment1": "Enter JSON to generate Substrait Plan"}'
       );
-
-    cy.get("#language")
-      .select("sql")
-      .get("#editor")
-      .contains("#editor", "-- Enter SQL query to generate Substrait Plan");
   });
 });

--- a/client/src/views/CodeView.vue
+++ b/client/src/views/CodeView.vue
@@ -80,7 +80,7 @@ export default {
         json: '{"_comment1": "Enter JSON to generate Substrait Plan"}',
       },
       code: "",
-      language: "json",
+      language: "sql",
       editor: null,
       schema: "",
     };


### PR DESCRIPTION
This PR makes the change for keeping SQL as the default option for the Code view in the visualizer.