### PR TITLE
feat: Deploy workflow should skip if secrets are absent

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -11,7 +11,12 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: >
+      github.ref == 'refs/heads/main' &&
+      secrets.DEPLOY_SSH_KEY &&
+      secrets.DEPLOY_HOST_DNS &&
+      secrets.DEPLOY_USERNAME &&
+      secrets.DEPLOY_TARGET_DIR
     steps:
       - uses: actions/checkout@v3
       - run: rm -rf .git

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -28,7 +28,12 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: >
+      github.ref == 'refs/heads/main' &&
+      secrets.DEPLOY_SSH_KEY &&
+      secrets.DEPLOY_HOST_DNS &&
+      secrets.DEPLOY_USERNAME &&
+      secrets.DEPLOY_TARGET_DIR
     needs: [build]
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This PR modifies the Deploy workflow to be skipped if the required secrets are not present. It is intended to skip the workflow for remote forks where deploy workflows are unnecessary.