### PR TITLE
Initial k8s deployment

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI, HTTPException, File, UploadFile, Form, Depends
+from fastapi import FastAPI, HTTPException, status, File, UploadFile, Form, Depends, Request
 from fastapi.openapi.utils import get_openapi
+from fastapi.routing import APIRouter
 from fastapi_health import health
 
 from motor.motor_asyncio import AsyncIOMotorCollection
@@ -17,40 +18,28 @@ from shareable import MongoDBConnection, PlanData
 
 from loguru import logger
 
-app = FastAPI()
+router = APIRouter()
 duckConn = None
-
 
 async def get_mongo_conn():
     return app.state.mongo_pool.initialize()
 
-
-@app.get("/")
-def ping():
-    return {"api_service": "up and running"}
-
-
-@app.on_event("startup")
-async def Initialize():
+@router.on_event("startup")
+def Initialize():
     global duckConn
     duckConn = ConnectDuckDB()
     app.state.mongo_pool = MongoDBConnection()
 
 
-@app.get("/health/duckdb/")
+@router.get("/health/duckcb/")
 def CheckBackendConn(conn):
     CheckDuckDBConnection(conn)
-
-
-@app.get("/health/mongodb/")
-def CheckMongoConn():
     app.state.mongo_pool.check()
 
+router.add_api_route("/health", health([CheckBackendConn]))
 
-app.add_api_route("/health", health([CheckBackendConn]))
 
-
-@app.post("/validate/")
+@router.post("/validate/")
 async def Validate(plan: dict, override_levels: list[int]):
     try:
         logger.info("Validating plan using substrait-validator!")
@@ -65,7 +54,7 @@ async def Validate(plan: dict, override_levels: list[int]):
         )
 
 
-@app.post("/validate/file/")
+@router.post("/validate/file/")
 async def ValidateFile(file: UploadFile = File(), override_levels: list[int] = Form()):
     try:
         logger.info("Validating file using substrait-validator!")
@@ -81,13 +70,13 @@ async def ValidateFile(file: UploadFile = File(), override_levels: list[int] = F
         )
 
 
-@app.post("/execute/duckdb/")
+@router.post("/execute/duckdb/")
 async def ExecuteBackend(data: list[str]):
     global duckConn
     return ExecuteDuckDb(data, duckConn)
 
 
-@app.post("/parse/")
+@router.post("/parse/")
 async def ParseToSubstrait(data: dict):
     global duckConn
     return ParseFromDuckDB(data, duckConn)
@@ -125,5 +114,10 @@ def SubstraitFiddleOpenAPI():
     app.openapi_schema = openapi_schema
     return app.openapi_schema
 
-
+app = FastAPI()
+app.include_router(router, prefix="/api")
 app.openapi = SubstraitFiddleOpenAPI
+
+@app.get("/")
+def global_ping():
+    return {"api_service": "up and running"}

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:18-alpine as builder
+WORKDIR /app
+COPY . .
+RUN npm ci
+RUN npm run build
+
+FROM nginx:stable-alpine
+WORKDIR /app/static
+COPY --from=builder /app/dist .
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,34 @@
+# When we deploy the frontend via docker we use nginx to serve
+# the static files.  This configuration is a basic nginx config
+# that serves the static files from the /app/static directory
+# and hosts them on port 8080.
+#
+# It needs to match the setup in the Dockerfile (e.g. the
+# Dockerfile needs to put the files in /app/static and this
+# file needs to be placed at /etc/nginx/nginx.conf).
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include mime.types;
+    sendfile on;
+
+    server {
+        listen 8080 default_server;
+        listen [::]:8080;
+
+        # Ideally, should figure this out.  I believe it to be specific
+        # to the environment.
+        # resolver 127.0.0.11;
+
+        # Since this is the default (and only server) we don't need a
+        # valid server_name.  _ is convention.
+        server_name _;
+        # Don't send nginx version in error pages.  Not really needed.
+        server_tokens off;
+
+        root /app/static;
+    }
+}

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: substrait-fiddle
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: substrait-fiddle
+        tier: backend
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: "Balanced"
+      containers:
+        - name: substrait-fiddle-backend
+          image: us-central1-docker.pkg.dev/substrait-fiddle/substrait-fiddle-backend/substrait-fiddle-backend:0.0.1-alpha4
+          ports:
+            - containerPort: 9090

--- a/k8s/backend-service.yaml
+++ b/k8s/backend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app: substrait-fiddle
+    tier: backend
+spec:
+  ports:
+    - port: 9090
+      targetPort: 9090
+  selector:
+    app: substrait-fiddle
+    tier: backend

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: substrait-fiddle
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: substrait-fiddle
+        tier: frontend
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: "Balanced"
+      containers:
+        - name: substrait-fiddle-frontend
+          image: us-central1-docker.pkg.dev/substrait-fiddle/substrait-fiddle-frontend/substrait-fiddle-frontend:0.0.1-alpha1
+          ports:
+            - containerPort: 8080

--- a/k8s/frontend-service.yaml
+++ b/k8s/frontend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: substrait-fiddle
+    tier: frontend
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: substrait-fiddle
+    tier: frontend

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: substrait-fiddle-ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.global-static-ip-name: substrait-fiddle-ip
+spec:
+  ingressClassName: "gce"
+  rules:
+    - http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 8080
+          - path: /api/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 9090


### PR DESCRIPTION
In order to prepare substrait-fiddle to be hosted in a more automated way I created a k8s deployment.  I was able to use this to deploy to GKE and http://substrait-fiddle.com is live once again.

A few caveats:

 * HTTPS is not enabled yet.  I'll work on that
 * This deployment uses GKE's ingress controller which is pretty limited.  Notably, it cannot rewrite paths. As a result I needed to change the fast-api endpoints to start with /api (instead of using rewrites).