### PR TITLE
fix: ghci secrets format in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,4 +28,4 @@ networks:
 secrets:
   vite_sess_secrt:
     external: true
-    name: "${secrets.VITE_SESSION_SECRET}"
+    name: "${{ secrets.VITE_SESSION_SECRET }}"


### PR DESCRIPTION
This PR should fix the minor issue with the format for passing the GHCI secrets in docker-compose