### PR TITLE
fix: vite session secrets in github ci

### DIFF
--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -25,9 +25,6 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
 
-    - name: Set Environment Variable
-      run: ssh -i ${{ secrets.DEPLOY_SSH_KEY }} ${{ secrets.DEPLOY_USERNAME }}@${{ secrets.DEPLOY_HOST_DNS }} "echo 'export VITE_SESSION_SECRET=${{ secrets.VITE_SESSION_SECRET }}' >> ~/.bashrc"
-
     - uses: matiasnu/github-action-ssh-docker-compose@7fb3aa789f898b63c3722e6beb2dafa1a70f0e22 # v2.0.3
       name: Docker-Compose Remote Deployment
       with:
@@ -35,6 +32,5 @@ jobs:
         ssh_private_key: ${{ secrets.DEPLOY_SSH_KEY }}
         ssh_user: ${{ secrets.DEPLOY_USERNAME }}
         docker_compose_prefix: deploy
-      env:
-        VITE_SESSION_SECRET: ${{ secrets.VITE_SESSION_SECRET }}
-        DUCKDB_POOL_SIZE: 5
+        secrets: |
+          "VITE_SESSION_SECRET=${{ secrets.VITE_SESSION_SECRET }}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,6 @@ services:
      - DUCKDB_POOL_SIZE=5
     networks:
       - fiddle-network
-    secrets:
-       - VITE_SESSION_SECRET
 
   client:
     build: ./client
@@ -18,14 +16,7 @@ services:
       - "8080:8080"
     networks:
       - fiddle-network
-    secrets:
-       - VITE_SESSION_SECRET
 
 networks:
   fiddle-network:
     driver: bridge
-
-secrets:
-  VITE_SESSION_SECRET:
-    external: true
-    name: ${{ secrets.VITE_SESSION_SECRET }}


### PR DESCRIPTION
This PR should fix the deployment of VITE_SESSION_SECRET in Github CI