### PR TITLE
Enabling TLS and adding mongoDB

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -25,7 +25,7 @@ http {
 
         # Since this is the default (and only server) we don't need a
         # valid server_name.  _ is convention.
-        server_name _;
+        server_name substrait-fiddle.com;
         # Don't send nginx version in error pages.  Not really needed.
         server_tokens off;
 
@@ -39,11 +39,14 @@ http {
             proxy_set_header Host $host;
             proxy_cache_bypass $http_upgrade;
         }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
     }
 
     server {
         listen 443 ssl;
-        listen [::]:443;
 
         # Ideally, should figure this out.  I believe it to be specific
         # to the environment.
@@ -51,10 +54,10 @@ http {
 
         # Since this is the default (and only server) we don't need a
         # valid server_name.  _ is convention.
-        server_name substrait-fiddle.com www.substrait-fiddle.com;
+        server_name substrait-fiddle.com;
 
-        ssl_certificate /etc/letsencrypt/live/tu_dominio.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/tu_dominio.com/privkey.pem
+        ssl_certificate /etc/letsencrypt/live/substrait-fiddle.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/substrait-fiddle.com/privkey.pem;
 
         root /app/static;
 
@@ -65,6 +68,10 @@ http {
             proxy_set_header Connection 'upgrade';
             proxy_set_header Host $host;
             proxy_cache_bypass $http_upgrade;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
         }
     }
 }

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -16,33 +16,9 @@ http {
     sendfile on;
 
     server {
-        listen 8080 default_server;
-        listen [::]:8080;
-
-        # Ideally, should figure this out.  I believe it to be specific
-        # to the environment.
-        # resolver 127.0.0.11;
-
-        # Since this is the default (and only server) we don't need a
-        # valid server_name.  _ is convention.
+        listen 8080;
         server_name substrait-fiddle.com;
-        # Don't send nginx version in error pages.  Not really needed.
-        server_tokens off;
-
-        root /app/static;
-
-        location /api/ {
-            proxy_pass http://api:9090;  # Use the service name instead of IP
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
-            proxy_set_header Host $host;
-            proxy_cache_bypass $http_upgrade;
-        }
-
-        location / {
-            try_files $uri $uri/ /index.html;
-        }
+        return 301 https://$host$request_uri;
     }
 
     server {

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -40,4 +40,31 @@ http {
             proxy_cache_bypass $http_upgrade;
         }
     }
+
+    server {
+        listen 443 ssl;
+        listen [::]:443;
+
+        # Ideally, should figure this out.  I believe it to be specific
+        # to the environment.
+        # resolver 127.0.0.11;
+
+        # Since this is the default (and only server) we don't need a
+        # valid server_name.  _ is convention.
+        server_name substrait-fiddle.com www.substrait-fiddle.com;
+
+        ssl_certificate /etc/letsencrypt/live/tu_dominio.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/tu_dominio.com/privkey.pem
+
+        root /app/static;
+
+        location /api/ {
+            proxy_pass http://api:9090;  # Use the service name instead of IP
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+    }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,9 +8,9 @@ services:
     environment:
      - DUCKDB_POOL_SIZE=5
      - VITE_SESSION_SECRET=$VITE_SESSION_SECRET
+     - PROD_MONGO_URL=mongodb://mongo:27017/
     networks:
       - fiddle-network
-
   client:
     build:
       context: ./client
@@ -24,18 +24,13 @@ services:
     environment:
      - NODE_ENV=production
     volumes:
-      - ./nginx/certbot/conf:/etc/letsencrypt
-      - ./nginx/certbot/www:/var/www/certbot
-    depends_on:
-      - certbot
-  certbot:
-    image: certbot/certbot
-    volumes:
-      - ./nginx/certbot/conf:/etc/letsencrypt
-      - ./nginx/certbot/www:/var/www/certbot
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
-    command: certonly --webroot --webroot-path=/var/www/certbot --email eng-oss-ops@voltrondata.com --agree-tos --no-eff-email --staging -d substrait-fiddle.com -d www.substrait-fiddle.com
-
+      - /etc/letsencrypt:/etc/letsencrypt
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+    networks:
+      - fiddle-network
 networks:
   fiddle-network:
     driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,10 +18,23 @@ services:
       - VITE_SESSION_SECRET=$VITE_SESSION_SECRET
     ports:
       - "80:8080"
+      - "443:443"
     networks:
       - fiddle-network
     environment:
      - NODE_ENV=production
+    volumes:
+      - ./nginx/certbot/conf:/etc/letsencrypt
+      - ./nginx/certbot/www:/var/www/certbot
+    depends_on:
+      - certbot
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - ./nginx/certbot/conf:/etc/letsencrypt
+      - ./nginx/certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    command: certonly --webroot --webroot-path=/var/www/certbot --email eng-oss-ops@voltrondata.com --agree-tos --no-eff-email --staging -d substrait-fiddle.com -d www.substrait-fiddle.com
 
 networks:
   fiddle-network:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,8 @@ services:
       - "27017:27017"
     networks:
       - fiddle-network
+    volumes:
+      - ~/mongo/data:/data/db
 networks:
   fiddle-network:
     driver: bridge


### PR DESCRIPTION
Enabled TLS, certs created with cerbot (letsencrypt)
redirect http -> https
mongo added with volume mounts to persist data