### PR TITLE
Removing http redirection to allow certbot automatic renewal

### DIFF
--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -10,6 +10,8 @@ on:
       - '.github/workflows/deploy-api-client.yml'
       - 'docker-compose.yaml'
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 15 * *'
 
 permissions:
   actions: write

--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -55,3 +55,15 @@ jobs:
           docker-compose rm -f
           docker-compose build --no-cache
           docker-compose up -d
+
+    - name: Cleanup unused docker images, volumes and build cache
+      uses: appleboy/ssh-action@v1.0.3
+      with:
+        host: ${{ secrets.DEPLOY_HOST_DNS }}
+        username: ${{ secrets.DEPLOY_USERNAME }}
+        key: ${{ secrets.DEPLOY_SSH_KEY }}
+        script: |
+          docker container prune -f
+          docker image prune -f
+          docker volume prune -f
+          docker builder prune -f

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -16,12 +16,6 @@ http {
     sendfile on;
 
     server {
-        listen 8080;
-        server_name substrait-fiddle.com;
-        return 301 https://$host$request_uri;
-    }
-
-    server {
         listen 443 ssl;
 
         # Ideally, should figure this out.  I believe it to be specific

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,6 @@ services:
       args:
       - VITE_SESSION_SECRET=$VITE_SESSION_SECRET
     ports:
-      - "80:8080"
       - "443:443"
     networks:
       - fiddle-network


### PR DESCRIPTION
We've had http redirection for a while now. I'm removing the redirection so we can use the certbot autorenewal process (needs port 80 free) to reduce manual steps. I believe by now people should be used to the https.

Let me know if you don't agree with this, other options are:

- Manually stop, renew and re-deploy every three months
- Use complicated prehooks and posthooks (we need to add some secrets here to the deployment)
- Another GHA workflow to do this, since we already have the secrets, maybe a cronjob that runs every 2 weeks and restarts the service

On top of that I've added an automatic re-deployment every month (cron) so it takes the new certificate if it's been generated, and added a step to cleanup docker resources so it doesn't use all the space on the instance